### PR TITLE
fix: openai streaming not working

### DIFF
--- a/src/Clients/OpenAI/OpenAIClient.php
+++ b/src/Clients/OpenAI/OpenAIClient.php
@@ -47,6 +47,7 @@ class OpenAIClient extends ApiClient implements CanCallChatCompletion, CanCallJs
         $this->request = new ChatCompletionRequest($messages, $model, $options);
         if ($this->request->isStreamed()) {
             $this->responseClass = PartialChatCompletionResponse::class;
+            $this->request->config()->add('stream', true);
         } else {
             $this->responseClass = ChatCompletionResponse::class;
         }
@@ -58,6 +59,7 @@ class OpenAIClient extends ApiClient implements CanCallChatCompletion, CanCallJs
         $this->request = new JsonCompletionRequest($messages, $responseFormat, $model, $options);
         if ($this->request->isStreamed()) {
             $this->responseClass = PartialJsonCompletionResponse::class;
+            $this->request->config()->add('stream', true);
         } else {
             $this->responseClass = JsonCompletionResponse::class;
         }
@@ -69,6 +71,7 @@ class OpenAIClient extends ApiClient implements CanCallChatCompletion, CanCallJs
         $this->request = new ToolsCallRequest($messages, $model, $tools, $toolChoice, $options);
         if ($this->request->isStreamed()) {
             $this->responseClass = PartialToolsCallResponse::class;
+            $this->request->config()->add('stream', true);
         } else {
             $this->responseClass = ToolsCallResponse::class;
         }


### PR DESCRIPTION
Hey,

This is required for streaming to work with guzzle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a streaming configuration option for chat, JSON, and tools API calls in the OpenAI client. This feature allows for enhanced response handling based on streaming preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->