### PR TITLE
Remove env loading from library

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -24,7 +24,7 @@ class Container implements ContainerInterface
     use Traits\PreventsCycles;
 
     public function __construct(EventDispatcher $events = null) {
-        $this->events = new EventDispatcher('configuration');
+        $this->events = $events ?? new EventDispatcher('configuration');
         $this->events->dispatch(new ContainerInitiated());
     }
 }

--- a/src/Instructor.php
+++ b/src/Instructor.php
@@ -45,9 +45,6 @@ class Instructor {
         // queue 'STARTED' event, to dispatch it after user is ready to handle it
         $this->queueEvent(new InstructorStarted());
 
-        // try loading .env (if paths are set)
-        Env::load();
-
         // main event dispatcher
         $this->events = $events ?? new EventDispatcher('instructor');
 

--- a/src/Utils/Env.php
+++ b/src/Utils/Env.php
@@ -38,7 +38,7 @@ class Env
     }
 
     public static function load() : void {
-        if (!isset(self::$paths) && !isset(self::$names)) {
+        if ([] === self::$paths && [] === self::$names) {
             return;
         }
         self::$dotenv = Dotenv::createImmutable(self::$paths, self::$names);


### PR DESCRIPTION
Looking for a .env file from within a package is suboptimal. The package should be agnostic of the environment. If it requires some envs, it should do so during the initialisation and explicitly, not by trying to find a .env file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `Container` class now supports an optional `EventDispatcher` parameter for more flexible instantiation.
  
- **Bug Fixes**
	- The `Instructor` class no longer loads environment variables during construction, streamlining the initialization process.

- **Documentation**
	- Enhanced clarity in the `get` and `load` methods of the `Env` class, improving readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->