### PR TITLE
Catch exceptions in validator

### DIFF
--- a/src/Validation/Validators/SymfonyValidator.php
+++ b/src/Validation/Validators/SymfonyValidator.php
@@ -14,8 +14,12 @@ class SymfonyValidator implements CanValidateObject
             ->addLoader(new AttributeLoader())
             ->getValidator();
 
-        $result = $validator->validate($dataObject);
-
+        try {
+            $result = $validator->validate($dataObject);
+        } catch (\Exception $e) {
+            return ValidationResult::make($errors, $e->getMessage());
+        }
+        
         $errors = [];
         foreach ($result as $error) {
             $path = $error->getPropertyPath();


### PR DESCRIPTION
If you want to e.g. use the `Currency` validator, you need to require `symfony/intl`.
At the moment, you won't ever see this exception message because it is swallowed.

> Symfony\Component\Validator\Exception\LogicException - The Intl component is required to use the Currency constraint. Try running "composer require symfony/intl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation process with improved error handling to capture exceptions during validation.

- **Bug Fixes**
	- Resolved issues related to unhandled exceptions in the validation method, ensuring more reliable feedback on validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->