### PR TITLE
Fix OpenAI driver to use max_completion_tokens instead of deprecated …

### DIFF
--- a/packages/polyglot/src/Inference/Drivers/OpenAI/OpenAIBodyFormat.php
+++ b/packages/polyglot/src/Inference/Drivers/OpenAI/OpenAIBodyFormat.php
@@ -33,12 +33,12 @@ class OpenAIBodyFormat implements CanMapRequestBody
             'messages' => $this->messageFormat->map($messages),
         ]), $options);
 
-        // max_tokens is deprecated in OpenAI API, use max_completion_tokens instead
-        if (isset($requestBody['max_tokens'])) {
+        // max_tokens is deprecated in OpenAI API, use max_completion_tokens instead.
+        // Preserve an explicitly provided max_completion_tokens (from options) if present.
+        if (array_key_exists('max_tokens', $requestBody) && !array_key_exists('max_completion_tokens', $requestBody)) {
             $requestBody['max_completion_tokens'] = $requestBody['max_tokens'];
-            unset($requestBody['max_tokens']);
         }
-
+        unset($requestBody['max_tokens']);
         if ($options['stream'] ?? false) {
             $requestBody['stream_options']['include_usage'] = true;
         }


### PR DESCRIPTION
…max_tokens

OpenAI deprecated max_tokens in favor of max_completion_tokens. Models like o3-mini reject requests with max_tokens. Updated OpenAIBodyFormat to convert the parameter, following the same pattern as Groq and Cerebras drivers.

I didn't add a test because I didn't see one for the other drivers. Instead, I ran the basic example examples/A01_Basics/Basic/run.php 

- before the fix with withModel('o3-mini') to show the failure
- after the fix with withModel('o3-mini'), and gpt-4o / no model specified to confirm both still work.

Can add a test if you'd like


For anyone else encountering this, today I'm working around it by having a driver in my config where 'maxTokens' => 0,' and setting "options => [ 'max_completion_tokens' => 1024]" or whatever; max_tokens gets filtered out of the current driver when it is 0. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores compatibility with the updated OpenAI API by switching to the new completion token parameter, avoiding issues from the deprecated setting with no change in user behavior.

* **Chores**
  * Aligns request formatting with the API's current conventions while preserving backward compatibility.

* **Documentation**
  * Adds notes clarifying the deprecation and the new parameter to guide future usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->