### PR TITLE
fix bug with Field::structure not being deserializable when nested in…

### DIFF
--- a/packages/dynamic/src/Traits/Field/HandlesCollectionPrototype.php
+++ b/packages/dynamic/src/Traits/Field/HandlesCollectionPrototype.php
@@ -19,7 +19,9 @@ trait HandlesCollectionPrototype
     public function clone() : self {
         $clone = clone $this;
         $clone->defaultValue = $this->defaultValue;
-        $clone->value = null;
+        // Only null the value if it's not a Structure definition
+        // Clone the Structure to avoid shared state between collection items
+        $clone->value = (isset($this->value) && $this->value instanceof Structure) ? $this->value->clone() : null;
         $clone->required = $this->required;
         $clone->prototype = $this->prototype;
         return $clone;

--- a/packages/dynamic/tests/Feature/StructureTest.php
+++ b/packages/dynamic/tests/Feature/StructureTest.php
@@ -310,3 +310,32 @@ it('handles structure with collection field', function() {
         ['stringProperty' => 'string1'],
     ]);
 });
+
+it('handles nested structures within collection items', function () {
+    $structure = Structure::define('test', [
+        Field::collection('items',
+            Structure::define('item', [
+                Field::structure('nested', [
+                    Field::string('value', 'A value')
+                ], 'Nested structure')
+            ], 'Item'),
+        'Items')
+    ]);
+    
+    $data = [
+        'items' => [
+            ['nested' => ['value' => 'hello']],
+            ['nested' => ['value' => 'world']]
+        ]
+    ];
+    
+    // This should deserialize correctly without errors
+    $result = $structure->fromArray($data);
+    
+    // Verify the structure was deserialized correctly
+    expect($result->get('items'))->toHaveCount(2);
+    expect($result->get('items')[0]->get('nested'))->toBeInstanceOf(Structure::class);
+    expect($result->get('items')[0]->get('nested')->get('value'))->toBe('hello');
+    expect($result->get('items')[1]->get('nested'))->toBeInstanceOf(Structure::class);
+    expect($result->get('items')[1]->get('nested')->get('value'))->toBe('world');
+});


### PR DESCRIPTION
… a Structure that is a collection item type

this fixes a bug I encountered. 

**Bug description:** 
When you create a Field::structure(), it stores the Structure definition in the field's value property. This is different from Field::collection() which uses the prototype property.

  During collection deserialization:
  1. For each collection item, we clone the item's Structure prototype
  2. Structure::clone() clones all its fields by calling Field::clone() on each
  3. The original Field::clone() always set value = null (assuming it contained runtime data)
  4. This erased the Structure definition for any Field::structure() fields
  5. Later, when deserializing that field, the code tries $structure->get('nested')->fromArray($data)
  6. But get('nested') returns null (since we erased the Structure), causing "Call to a member function fromArray() on null"

I added a unit-test that reproduces the bug. 

**Fix description:** 
Modified Field::clone() to preserve Structure definitions and clone them to avoid shared state:
  $clone->value = (isset($this->value) && $this->value instanceof Structure) ? $this->value->clone() : null;

Instead of always nulling the value property (which erased Structure definitions), we now check if it contains a Structure. If it does, we clone it so each collection item gets its own independent Structure instance. This preserves the schema definition needed for deserialization and prevents all collection items from sharing the same Structure instance (which would cause them to overwrite each other's data).

I believe this is safe because Field::structure() uses value to store the schema definition (the template), not runtime data - and it is the pattern of how nested structures work outside of collections. All existing tests pass.

Admittedly it's a bit ugly  and not great to have the instanceof check. But I wanted to submit a quick fix to at least open discussion.

**Possible Alternatives**

The real underlying challenge is that Field::structure uses value both to hold the schema and the data. Like I said I think this is fine for collections because during deserialization we always start off with a 'pristine' structure that only has the schema, and we clone before we populate with data. But it's confusing. 

1.  Make Field::structure() use prototype like Field::collection() does:
```
  static public function structure(string $name, array|callable $fields, string $description = '') : self {
      $structure = Structure::define($name, $fields, $description);
      return new Field(
          name: $name,
          description: $description,
          typeDetails: TypeDetails::object(Structure::class),
          prototype: $structure  // Use prototype instead of set()
      );
  }
```
  This would make the storage consistent - both collections and nested structures would use prototype for their schema definitions. However, this approach would require modifying the deserialization logic (line 51 in HandlesDeserialization.php) to check prototype when deserializing nested structures, not just value. It's a more architecturally consistent solution but requires changes in multiple places and could break existing code that expects nested structures in value.

2. Add some generic 'preserve value on clone' property to Field and have Field::structure set it. But I didn't want to do this  without discussion because it seems like not really better than instanceOf and doesn't address the underlying problem any more. 

