### PR TITLE
Add missing symfony/property-access dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
     "psr/log": "^3.0",
     "symfony/console": "^6.4|^7.1",
     "symfony/filesystem": "^6.4|^7.1",
+    "symfony/property-access": "^6.4|^7.0",
     "symfony/property-info": "^6.4|^7.0",
     "symfony/serializer": "^6.4|^7.0",
     "symfony/validator": "^6.4 || ^7.0",


### PR DESCRIPTION
Hi there! I just installed Instructor and was experimenting with the [Ollama example](https://docs.instructorphp.com/cookbook/instructor/api_support/ollama#example) in the docs.

The example wouldn't run due to `Class "Symfony\Component\PropertyAccess\PropertyAccess" not found`.

Running `composer require symfony/property-access` fixed it and now it works perfectly, so this PR just adds the missing dependency in to `composer.json`.

Thanks for an incredible package! 🙏