### PR TITLE
Calculating cost of request

### DIFF
--- a/examples/A03_Troubleshooting/CostCalculation/run.php
+++ b/examples/A03_Troubleshooting/CostCalculation/run.php
@@ -77,8 +77,8 @@ $response = (new StructuredOutput)
 // Define pricing for default model gpt-4.1-nano
 $pricing = Pricing::fromArray([
     'input' => 0.2,     // $0.2 per 1M input tokens
-    'output' => 0.8,   // $15 per 1M output tokens
-    'cacheRead' => 0.05, // $15 per 1M output tokens
+    'output' => 0.8,   // $0.8 per 1M output tokens
+    'cacheRead' => 0.05, // $0.05 per 1M output tokens
 ]);
 
 echo "TEXT: $text\n\n";

--- a/examples/A03_Troubleshooting/CostCalculation/run.php
+++ b/examples/A03_Troubleshooting/CostCalculation/run.php
@@ -40,7 +40,7 @@ function printCostBreakdown(Usage $usage, Pricing $pricing): void {
     echo "  Input:      \${$pricing->inputPerMToken}\n";
     echo "  Output:     \${$pricing->outputPerMToken}\n";
     echo "  Cache read: \${$pricing->cacheReadPerMToken}\n";
-    echo "\nTotal cost: \$" . number_format($usage->calculateCost(), 6) . "\n";
+    echo "\nTotal cost: \$" . number_format($usage->calculateCost($pricing), 6) . "\n";
 }
 
 // OPTION 1: Configure pricing in LLM config preset
@@ -76,10 +76,11 @@ $response = (new StructuredOutput)
         responseModel: User::class,
     )->response();
 
-// Define pricing for Claude 3.5 Sonnet ($/1M tokens)
+// Define pricing for default model gpt-4.1-nano
 $pricing = Pricing::fromArray([
-    'input' => 3.0,     // $3 per 1M input tokens
-    'output' => 15.0,   // $15 per 1M output tokens
+    'input' => 0.2,     // $0.2 per 1M input tokens
+    'output' => 0.8,   // $15 per 1M output tokens
+    'cacheRead' => 0.05, // $15 per 1M output tokens
 ]);
 
 echo "TEXT: $text\n\n";

--- a/examples/A03_Troubleshooting/CostCalculation/run.php
+++ b/examples/A03_Troubleshooting/CostCalculation/run.php
@@ -1,0 +1,115 @@
+---
+title: 'Calculating request cost'
+docname: 'cost_calculation'
+---
+
+## Overview
+
+When using LLM APIs, tracking costs is essential for budgeting and optimization.
+Instructor supports automatic cost calculation based on token usage and pricing
+configuration in your LLM presets.
+
+This example demonstrates how to:
+1. Configure pricing in LLM config ($/1M tokens)
+2. Calculate cost after a request using `Usage::calculateCost()`
+
+## Example
+
+```php
+<?php
+require 'examples/boot.php';
+
+use Cognesy\Instructor\StructuredOutput;
+use Cognesy\Polyglot\Inference\Data\Pricing;
+use Cognesy\Polyglot\Inference\Data\Usage;
+
+class User {
+    public int $age;
+    public string $name;
+}
+
+// Helper to display cost breakdown
+function printCostBreakdown(Usage $usage, Pricing $pricing): void {
+    echo "Token Usage:\n";
+    echo "  Input tokens:     {$usage->inputTokens}\n";
+    echo "  Output tokens:    {$usage->outputTokens}\n";
+    echo "  Cache read:       {$usage->cacheReadTokens}\n";
+    echo "  Cache write:      {$usage->cacheWriteTokens}\n";
+    echo "  Reasoning:        {$usage->reasoningTokens}\n";
+    echo "\nPricing ($/1M tokens):\n";
+    echo "  Input:      \${$pricing->inputPerMToken}\n";
+    echo "  Output:     \${$pricing->outputPerMToken}\n";
+    echo "  Cache read: \${$pricing->cacheReadPerMToken}\n";
+    echo "\nTotal cost: \$" . number_format($usage->calculateCost(), 6) . "\n";
+}
+
+// OPTION 1: Configure pricing in LLM config preset
+// In your config/llm.php, add pricing to your preset:
+//
+// 'openrouter-claude' => [
+//     'driver' => 'openrouter',
+//     'model' => 'anthropic/claude-3.5-sonnet',
+//     'pricing' => [
+//         'input' => 3.0,    // $3 per 1M input tokens
+//         'output' => 15.0,  // $15 per 1M output tokens
+//         // cacheRead, cacheWrite, reasoning default to input price if not set
+//     ],
+// ],
+//
+// Then calculateCost() works automatically:
+//
+// $response = (new StructuredOutput)
+//     ->using('openrouter-claude')
+//     ->with(messages: $text, responseModel: User::class)
+//     ->response();
+// $cost = $response->usage()->calculateCost();
+
+// OPTION 2: Calculate cost manually with explicit Pricing
+echo "CALCULATING COST WITH EXPLICIT PRICING\n";
+echo str_repeat("=", 50) . "\n\n";
+
+$text = "Jason is 25 years old and works as an engineer.";
+
+$response = (new StructuredOutput)
+    ->with(
+        messages: $text,
+        responseModel: User::class,
+    )->response();
+
+// Define pricing for Claude 3.5 Sonnet ($/1M tokens)
+$pricing = Pricing::fromArray([
+    'input' => 3.0,     // $3 per 1M input tokens
+    'output' => 15.0,   // $15 per 1M output tokens
+]);
+
+echo "TEXT: $text\n\n";
+printCostBreakdown($response->usage(), $pricing);
+
+// You can also attach pricing to usage for later calculation
+$usageWithPricing = $response->usage()->withPricing($pricing);
+echo "\nCost via stored pricing: \$" . number_format($usageWithPricing->calculateCost(), 6) . "\n";
+
+
+// OPTION 3: Compare costs across different models
+echo "\n\n" . str_repeat("=", 50) . "\n";
+echo "COST COMPARISON ACROSS MODELS\n";
+echo str_repeat("=", 50) . "\n\n";
+
+$usage = $response->usage();
+
+$models = [
+    'GPT-4o' => ['input' => 2.50, 'output' => 10.0],
+    'GPT-4o-mini' => ['input' => 0.15, 'output' => 0.60],
+    'Claude 3.5 Sonnet' => ['input' => 3.0, 'output' => 15.0],
+    'Claude 3.5 Haiku' => ['input' => 0.80, 'output' => 4.0],
+    'Gemini 2.0 Flash' => ['input' => 0.10, 'output' => 0.40],
+];
+
+echo "For {$usage->inputTokens} input + {$usage->outputTokens} output tokens:\n\n";
+foreach ($models as $model => $prices) {
+    $pricing = Pricing::fromArray($prices);
+    $cost = $usage->calculateCost($pricing);
+    printf("  %-20s \$%.6f\n", $model, $cost);
+}
+?>
+```

--- a/examples/A03_Troubleshooting/CostCalculation/run.php
+++ b/examples/A03_Troubleshooting/CostCalculation/run.php
@@ -13,8 +13,6 @@ This example demonstrates how to:
 1. Configure pricing in LLM config ($/1M tokens)
 2. Calculate cost after a request using `Usage::calculateCost()`
 
-## Example
-
 ```php
 <?php
 require 'examples/boot.php';
@@ -40,7 +38,7 @@ function printCostBreakdown(Usage $usage, Pricing $pricing): void {
     echo "  Input:      \${$pricing->inputPerMToken}\n";
     echo "  Output:     \${$pricing->outputPerMToken}\n";
     echo "  Cache read: \${$pricing->cacheReadPerMToken}\n";
-    echo "\nTotal cost: \$" . number_format($usage->calculateCost(), 6) . "\n";
+    echo "\nTotal cost: \$" . number_format($usage->calculateCost($pricing), 6) . "\n";
 }
 
 // OPTION 1: Configure pricing in LLM config preset

--- a/packages/polyglot/src/Inference/Collections/InferenceAttemptList.php
+++ b/packages/polyglot/src/Inference/Collections/InferenceAttemptList.php
@@ -67,6 +67,26 @@ class InferenceAttemptList
         return new self($this->attempts->withAppended($attempt));
     }
 
+    /**
+     * Updates the last attempt with the given one (by matching ID).
+     */
+    public function withUpdatedAttempt(InferenceAttempt $attempt): self {
+        $items = $this->attempts->all();
+        $updated = false;
+        foreach ($items as $index => $existing) {
+            if ($existing->id === $attempt->id) {
+                $items[$index] = $attempt;
+                $updated = true;
+                break;
+            }
+        }
+        if (!$updated && count($items) > 0) {
+            // Fallback: replace last if ID not found
+            $items[count($items) - 1] = $attempt;
+        }
+        return new self(ArrayList::fromArray($items));
+    }
+
     // SERIALIZATION /////////////////////////////////////////
 
     public function toArray(): array {

--- a/packages/polyglot/src/Inference/Collections/InferenceAttemptList.php
+++ b/packages/polyglot/src/Inference/Collections/InferenceAttemptList.php
@@ -5,6 +5,7 @@ namespace Cognesy\Polyglot\Inference\Collections;
 use Cognesy\Polyglot\Inference\Data\InferenceAttempt;
 use Cognesy\Polyglot\Inference\Data\Usage;
 use Cognesy\Utils\Collection\ArrayList;
+use InvalidArgumentException;
 
 class InferenceAttemptList
 {
@@ -68,7 +69,9 @@ class InferenceAttemptList
     }
 
     /**
-     * Updates the last attempt with the given one (by matching ID).
+     * Updates an attempt with the given one (by matching ID).
+     *
+     * @throws InvalidArgumentException If no attempt with the given ID exists
      */
     public function withUpdatedAttempt(InferenceAttempt $attempt): self {
         $items = $this->attempts->all();
@@ -80,9 +83,10 @@ class InferenceAttemptList
                 break;
             }
         }
-        if (!$updated && count($items) > 0) {
-            // Fallback: replace last if ID not found
-            $items[count($items) - 1] = $attempt;
+        if (!$updated) {
+            throw new InvalidArgumentException(
+                "Cannot update attempt: no attempt found with ID '{$attempt->id}'"
+            );
         }
         return new self(ArrayList::fromArray($items));
     }

--- a/packages/polyglot/src/Inference/Config/LLMConfig.php
+++ b/packages/polyglot/src/Inference/Config/LLMConfig.php
@@ -3,6 +3,7 @@
 namespace Cognesy\Polyglot\Inference\Config;
 
 use Cognesy\Config\Exceptions\ConfigurationException;
+use Cognesy\Polyglot\Inference\Data\Pricing;
 use InvalidArgumentException;
 use Throwable;
 
@@ -26,6 +27,7 @@ final class LLMConfig
         public int    $maxOutputLength = 4096,
         public string $driver = 'openai-compatible',
         public array  $options = [],
+        public array  $pricing = [],
     ) {
         $this->assertNoRetryPolicyInOptions($this->options);
     }
@@ -62,7 +64,12 @@ final class LLMConfig
             'maxOutputLength' => $this->maxOutputLength,
             'driver' => $this->driver,
             'options' => $this->options,
+            'pricing' => $this->pricing,
         ];
+    }
+
+    public function getPricing(): Pricing {
+        return Pricing::fromArray($this->pricing);
     }
 
     private function assertNoRetryPolicyInOptions(array $options) : void {

--- a/packages/polyglot/src/Inference/Data/InferenceExecution.php
+++ b/packages/polyglot/src/Inference/Data/InferenceExecution.php
@@ -271,6 +271,21 @@ class InferenceExecution
             isFinalized: true,
         );
     }
+
+    /**
+     * Updates the response in the current attempt (e.g., to attach pricing).
+     */
+    public function withUpdatedResponse(InferenceResponse $response): self {
+        if ($this->currentAttempt === null) {
+            return $this;
+        }
+        $updatedAttempt = $this->currentAttempt->withResponse($response);
+        return $this->with(
+            attempts: $this->attempts->withUpdatedAttempt($updatedAttempt),
+            currentAttempt: $updatedAttempt,
+        );
+    }
+
     private function withFinalizedAttempt(InferenceAttempt $attempt): self {
         return $this->with(
             attempts: $this->attempts->withNewAttempt($attempt),

--- a/packages/polyglot/src/Inference/Data/InferenceResponse.php
+++ b/packages/polyglot/src/Inference/Data/InferenceResponse.php
@@ -195,6 +195,10 @@ final readonly class InferenceResponse
         return $this->with(content: $content);
     }
 
+    public function withPricing(Pricing $pricing): self {
+        return $this->with(usage: $this->usage->withPricing($pricing));
+    }
+
     public function withReasoningContentFallbackFromContent(): self {
         if ($this->reasoningContent !== '') {
             return $this;

--- a/packages/polyglot/src/Inference/Data/Pricing.php
+++ b/packages/polyglot/src/Inference/Data/Pricing.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Cognesy\Polyglot\Inference\Data;
+
+/**
+ * Pricing configuration for LLM token costs.
+ * All prices are in USD per 1,000,000 tokens (per 1M tokens).
+ */
+final class Pricing
+{
+    public readonly float $inputPerMToken;
+    public readonly float $outputPerMToken;
+    public readonly float $cacheReadPerMToken;
+    public readonly float $cacheWritePerMToken;
+    public readonly float $reasoningPerMToken;
+
+    public function __construct(
+        float $inputPerMToken = 0.0,
+        float $outputPerMToken = 0.0,
+        ?float $cacheReadPerMToken = null,
+        ?float $cacheWritePerMToken = null,
+        ?float $reasoningPerMToken = null,
+    ) {
+        $this->inputPerMToken = $inputPerMToken;
+        $this->outputPerMToken = $outputPerMToken;
+        // Default to input price if not specified
+        $this->cacheReadPerMToken = $cacheReadPerMToken ?? $inputPerMToken;
+        $this->cacheWritePerMToken = $cacheWritePerMToken ?? $inputPerMToken;
+        $this->reasoningPerMToken = $reasoningPerMToken ?? $inputPerMToken;
+    }
+
+    // CONSTRUCTORS ///////////////////////////////////////////////////////
+
+    public static function none(): self {
+        return new self();
+    }
+
+    /**
+     * Create from array with prices in $/1M tokens.
+     * Keys: input, output, cacheRead, cacheWrite, reasoning
+     * If cacheRead, cacheWrite, or reasoning are not specified, they default to input price.
+     */
+    public static function fromArray(array $data): self {
+        $input = (float) ($data['input'] ?? $data['inputPerMToken'] ?? 0.0);
+        return new self(
+            inputPerMToken: $input,
+            outputPerMToken: (float) ($data['output'] ?? $data['outputPerMToken'] ?? 0.0),
+            cacheReadPerMToken: isset($data['cacheRead']) || isset($data['cacheReadPerMToken'])
+                ? (float) ($data['cacheRead'] ?? $data['cacheReadPerMToken'])
+                : null,
+            cacheWritePerMToken: isset($data['cacheWrite']) || isset($data['cacheWritePerMToken'])
+                ? (float) ($data['cacheWrite'] ?? $data['cacheWritePerMToken'])
+                : null,
+            reasoningPerMToken: isset($data['reasoning']) || isset($data['reasoningPerMToken'])
+                ? (float) ($data['reasoning'] ?? $data['reasoningPerMToken'])
+                : null,
+        );
+    }
+
+    // ACCESSORS //////////////////////////////////////////////////////////
+
+    public function hasAnyPricing(): bool {
+        return $this->inputPerMToken > 0.0
+            || $this->outputPerMToken > 0.0;
+    }
+
+    // TRANSFORMERS ///////////////////////////////////////////////////////
+
+    public function toArray(): array {
+        return [
+            'input' => $this->inputPerMToken,
+            'output' => $this->outputPerMToken,
+            'cacheRead' => $this->cacheReadPerMToken,
+            'cacheWrite' => $this->cacheWritePerMToken,
+            'reasoning' => $this->reasoningPerMToken,
+        ];
+    }
+}

--- a/packages/polyglot/src/Inference/Drivers/BaseInferenceDriver.php
+++ b/packages/polyglot/src/Inference/Drivers/BaseInferenceDriver.php
@@ -74,6 +74,12 @@ abstract class BaseInferenceDriver implements CanHandleInference
             throw $e;
         }
 
+        // Attach pricing from config if available
+        $pricing = $this->config->getPricing();
+        if ($pricing->hasAnyPricing()) {
+            $inferenceResponse = $inferenceResponse->withPricing($pricing);
+        }
+
         $this->events->dispatch(new InferenceResponseCreated(['response' => $inferenceResponse->toArray()]));
         return $inferenceResponse;
     }

--- a/packages/polyglot/src/Inference/Inference.php
+++ b/packages/polyglot/src/Inference/Inference.php
@@ -17,6 +17,7 @@ use Cognesy\Polyglot\Inference\Creation\InferenceRequestBuilder;
 use Cognesy\Polyglot\Inference\Data\InferenceExecution;
 use Cognesy\Polyglot\Inference\Data\InferenceRequest;
 use Cognesy\Polyglot\Inference\Data\InferenceResponse;
+use Cognesy\Polyglot\Inference\Data\Pricing;
 use Cognesy\Polyglot\Inference\Enums\OutputMode;
 use Cognesy\Polyglot\Inference\Streaming\InferenceStream;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -120,10 +121,16 @@ class Inference
         $inferenceDriver = $this->makeInferenceDriver($httpClient);
         $request = $this->requestBuilder->create();
         $execution = InferenceExecution::fromRequest($request);
+
+        // Get pricing from config if available
+        $resolver = $this->llmResolver ?? $this->llmProvider;
+        $pricing = $resolver->resolveConfig()->getPricing();
+
         return new PendingInference(
             execution: $execution,
             driver: $inferenceDriver,
             eventDispatcher: $this->events,
+            pricing: $pricing->hasAnyPricing() ? $pricing : null,
         );
     }
 

--- a/packages/polyglot/src/Inference/PendingInference.php
+++ b/packages/polyglot/src/Inference/PendingInference.php
@@ -8,6 +8,7 @@ use Cognesy\Polyglot\Inference\Creation\InferenceRequestBuilder;
 use Cognesy\Polyglot\Inference\Data\InferenceExecution;
 use Cognesy\Polyglot\Inference\Data\InferenceRequest;
 use Cognesy\Polyglot\Inference\Data\InferenceResponse;
+use Cognesy\Polyglot\Inference\Data\Pricing;
 use Cognesy\Polyglot\Inference\Enums\InferenceFinishReason;
 use Cognesy\Polyglot\Inference\Enums\ResponseCachePolicy;
 use Cognesy\Polyglot\Inference\Events\InferenceAttemptFailed;
@@ -36,6 +37,7 @@ class PendingInference
     protected readonly EventDispatcherInterface $events;
 
     protected InferenceExecution $execution;
+    private ?Pricing $pricing;
 
     private ?DateTimeImmutable $startedAt = null;
     private ?DateTimeImmutable $attemptStartedAt = null;
@@ -47,10 +49,12 @@ class PendingInference
         InferenceExecution $execution,
         CanHandleInference $driver,
         EventDispatcherInterface $eventDispatcher,
+        ?Pricing $pricing = null,
     ) {
         $this->execution = $execution;
         $this->events = $eventDispatcher;
         $this->driver = $driver;
+        $this->pricing = $pricing;
     }
 
     /**
@@ -92,6 +96,7 @@ class PendingInference
             driver: $this->driver,
             eventDispatcher: $this->events,
             cachePolicy: $this->cachePolicy(),
+            pricing: $this->pricing,
         );
         $this->cachedStream = $stream;
         return $stream;

--- a/packages/polyglot/tests/Unit/Data/UsageCostCalculationTest.php
+++ b/packages/polyglot/tests/Unit/Data/UsageCostCalculationTest.php
@@ -1,0 +1,202 @@
+<?php declare(strict_types=1);
+
+use Cognesy\Polyglot\Inference\Data\Pricing;
+use Cognesy\Polyglot\Inference\Data\Usage;
+
+describe('Pricing', function () {
+    it('creates pricing from array with short keys', function () {
+        $pricing = Pricing::fromArray([
+            'input' => 3.0,
+            'output' => 15.0,
+            'cacheRead' => 0.3,
+            'cacheWrite' => 3.75,
+            'reasoning' => 60.0,
+        ]);
+
+        expect($pricing->inputPerMToken)->toBe(3.0)
+            ->and($pricing->outputPerMToken)->toBe(15.0)
+            ->and($pricing->cacheReadPerMToken)->toBe(0.3)
+            ->and($pricing->cacheWritePerMToken)->toBe(3.75)
+            ->and($pricing->reasoningPerMToken)->toBe(60.0);
+    });
+
+    it('creates pricing from array with long keys', function () {
+        $pricing = Pricing::fromArray([
+            'inputPerMToken' => 3.0,
+            'outputPerMToken' => 15.0,
+        ]);
+
+        expect($pricing->inputPerMToken)->toBe(3.0)
+            ->and($pricing->outputPerMToken)->toBe(15.0);
+    });
+
+    it('defaults cache and reasoning to input price', function () {
+        $pricing = Pricing::fromArray([
+            'input' => 3.0,
+            'output' => 15.0,
+        ]);
+
+        expect($pricing->cacheReadPerMToken)->toBe(3.0)
+            ->and($pricing->cacheWritePerMToken)->toBe(3.0)
+            ->and($pricing->reasoningPerMToken)->toBe(3.0);
+    });
+
+    it('returns empty pricing with none()', function () {
+        $pricing = Pricing::none();
+
+        expect($pricing->hasAnyPricing())->toBeFalse();
+    });
+
+    it('detects when pricing is configured', function () {
+        $pricing = Pricing::fromArray(['input' => 1.0]);
+
+        expect($pricing->hasAnyPricing())->toBeTrue();
+    });
+
+    it('converts to array', function () {
+        $pricing = new Pricing(
+            inputPerMToken: 3.0,
+            outputPerMToken: 15.0,
+        );
+
+        expect($pricing->toArray())->toBe([
+            'input' => 3.0,
+            'output' => 15.0,
+            'cacheRead' => 3.0,
+            'cacheWrite' => 3.0,
+            'reasoning' => 3.0,
+        ]);
+    });
+});
+
+describe('Usage::calculateCost', function () {
+    it('calculates cost for input and output tokens ($/1M)', function () {
+        $usage = new Usage(
+            inputTokens: 1_000_000,
+            outputTokens: 500_000,
+        );
+        $pricing = new Pricing(
+            inputPerMToken: 3.0,
+            outputPerMToken: 15.0,
+        );
+
+        // (1M/1M) * 3.0 + (500K/1M) * 15.0 = 3.0 + 7.5 = 10.5
+        $cost = $usage->calculateCost($pricing);
+
+        expect($cost)->toBe(10.5);
+    });
+
+    it('calculates cost including cache tokens', function () {
+        $usage = new Usage(
+            inputTokens: 1_000_000,
+            outputTokens: 500_000,
+            cacheReadTokens: 2_000_000,
+            cacheWriteTokens: 500_000,
+        );
+        $pricing = new Pricing(
+            inputPerMToken: 3.0,
+            outputPerMToken: 15.0,
+            cacheReadPerMToken: 0.3,
+            cacheWritePerMToken: 3.75,
+        );
+
+        // input: 1 * 3.0 = 3.0
+        // output: 0.5 * 15.0 = 7.5
+        // cacheRead: 2 * 0.3 = 0.6
+        // cacheWrite: 0.5 * 3.75 = 1.875
+        // total = 12.975
+        $cost = $usage->calculateCost($pricing);
+
+        expect($cost)->toBe(12.975);
+    });
+
+    it('calculates cost including reasoning tokens', function () {
+        $usage = new Usage(
+            inputTokens: 1_000_000,
+            outputTokens: 200_000,
+            reasoningTokens: 800_000,
+        );
+        $pricing = new Pricing(
+            inputPerMToken: 3.0,
+            outputPerMToken: 15.0,
+            reasoningPerMToken: 60.0,
+        );
+
+        // input: 1 * 3.0 = 3.0
+        // output: 0.2 * 15.0 = 3.0
+        // reasoning: 0.8 * 60.0 = 48.0
+        // total = 54.0
+        $cost = $usage->calculateCost($pricing);
+
+        expect($cost)->toBe(54.0);
+    });
+
+    it('throws when no pricing available and none provided', function () {
+        $usage = new Usage(
+            inputTokens: 1000,
+            outputTokens: 500,
+        );
+
+        expect(fn() => $usage->calculateCost())
+            ->toThrow(\RuntimeException::class, 'Cannot calculate cost: no pricing information available');
+    });
+
+    it('returns zero cost with no usage', function () {
+        $usage = Usage::none();
+        $pricing = new Pricing(
+            inputPerMToken: 3.0,
+            outputPerMToken: 15.0,
+        );
+
+        $cost = $usage->calculateCost($pricing);
+
+        expect($cost)->toBe(0.0);
+    });
+
+    it('uses stored pricing when no argument provided', function () {
+        $pricing = new Pricing(
+            inputPerMToken: 3.0,
+            outputPerMToken: 15.0,
+        );
+        $usage = (new Usage(
+            inputTokens: 1_000_000,
+            outputTokens: 500_000,
+        ))->withPricing($pricing);
+
+        // No argument - uses stored pricing
+        $cost = $usage->calculateCost();
+
+        expect($cost)->toBe(10.5);
+    });
+
+    it('calculates realistic OpenRouter Claude pricing', function () {
+        // Real Claude 3.5 Sonnet pricing via OpenRouter: $3/1M input, $15/1M output
+        $usage = new Usage(
+            inputTokens: 15_000,
+            outputTokens: 2_500,
+        );
+        $pricing = Pricing::fromArray([
+            'input' => 3.0,    // $/1M tokens
+            'output' => 15.0,  // $/1M tokens
+        ]);
+
+        // input: 0.015 * 3.0 = 0.045
+        // output: 0.0025 * 15.0 = 0.0375
+        // total = 0.0825
+        $cost = $usage->calculateCost($pricing);
+
+        expect($cost)->toBe(0.0825);
+    });
+
+    it('preserves pricing through accumulation', function () {
+        $pricing = new Pricing(inputPerMToken: 3.0, outputPerMToken: 15.0);
+
+        $usage1 = (new Usage(inputTokens: 500_000))->withPricing($pricing);
+        $usage2 = new Usage(inputTokens: 500_000);
+
+        $accumulated = $usage1->withAccumulated($usage2);
+
+        expect($accumulated->pricing())->toBe($pricing)
+            ->and($accumulated->calculateCost())->toBe(3.0); // 1M * 3.0
+    });
+});

--- a/packages/polyglot/tests/Unit/Data/UsageCostCalculationTest.php
+++ b/packages/polyglot/tests/Unit/Data/UsageCostCalculationTest.php
@@ -67,6 +67,36 @@ describe('Pricing', function () {
             'reasoning' => 3.0,
         ]);
     });
+
+    it('throws on non-numeric input value', function () {
+        expect(fn() => Pricing::fromArray(['input' => 'invalid']))
+            ->toThrow(InvalidArgumentException::class, "Pricing field 'input' must be numeric");
+    });
+
+    it('throws on non-numeric output value', function () {
+        expect(fn() => Pricing::fromArray(['input' => 1.0, 'output' => 'bad']))
+            ->toThrow(InvalidArgumentException::class, "Pricing field 'output' must be numeric");
+    });
+
+    it('throws on negative pricing value', function () {
+        expect(fn() => Pricing::fromArray(['input' => -5.0]))
+            ->toThrow(InvalidArgumentException::class, "Pricing field 'input' must be non-negative");
+    });
+
+    it('throws on negative cacheRead value', function () {
+        expect(fn() => Pricing::fromArray(['input' => 1.0, 'cacheRead' => -0.5]))
+            ->toThrow(InvalidArgumentException::class, "Pricing field 'cacheRead' must be non-negative");
+    });
+
+    it('accepts numeric strings', function () {
+        $pricing = Pricing::fromArray([
+            'input' => '3.0',
+            'output' => '15',
+        ]);
+
+        expect($pricing->inputPerMToken)->toBe(3.0)
+            ->and($pricing->outputPerMToken)->toBe(15.0);
+    });
 });
 
 describe('Usage::calculateCost', function () {

--- a/packages/polyglot/tests/Unit/Data/UsageCostCalculationTest.php
+++ b/packages/polyglot/tests/Unit/Data/UsageCostCalculationTest.php
@@ -137,7 +137,7 @@ describe('Usage::calculateCost', function () {
         // total = 12.975
         $cost = $usage->calculateCost($pricing);
 
-        expect($cost)->toBe(12.975);
+        expect($cost)->toBeCloseTo(12.975, 6);
     });
 
     it('calculates cost including reasoning tokens', function () {
@@ -215,7 +215,7 @@ describe('Usage::calculateCost', function () {
         // total = 0.0825
         $cost = $usage->calculateCost($pricing);
 
-        expect($cost)->toBe(0.0825);
+        expect($cost)->toBeCloseTo(0.0825, 6);
     });
 
     it('preserves pricing through accumulation', function () {


### PR DESCRIPTION
Calculating the cost of a request based on a pre-set pricing list

Config `llm.php`:
```
    'presets' => [
        'openrouter-flash3' => [
            'driver' => 'openrouter',
            'model' => 'google/gemini-3-flash-preview',
            ...
            'pricing' => [
                'input' => 0.5,    // $0.5 per 1M input tokens
                'output' => 3.0,  // $3 per 1M output tokens
                // cacheRead, cacheWrite, reasoning default to input price if not set
        ],
        ...
```

Usage:
```
$response = (new StructuredOutput)
    ->using('openrouter-flash3')
    ->with(messages: $messages, responseModel: SomeSchema::class)
    ->response();
$cost = $response->usage()->calculateCost();
```   

Usage without config changes:
```
$response = (new StructuredOutput)
    ->using('openrouter-flash3')
    ->with(messages: $messages, responseModel: SomeSchema::class)
    ->response();
$pricing = Pricing::fromArray([
    'input' => 0.5,
    'output' => 3,
]);
$cost = $response->usage()->calculateCost($pricing);
     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM token cost estimation integrated across inference flow; pricing can come from model config or be attached to responses/usages.
  * Pricing supports input, output, cache read/write, and reasoning rates.

* **Examples**
  * New PHP example demonstrating cost breakdowns, multiple pricing patterns, and model cost comparisons.

* **Tests**
  * Comprehensive unit tests for pricing creation, serialization, cost calculations, accumulation, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->